### PR TITLE
Convert to latest swift syntax and include tvOS and OSX

### DIFF
--- a/SwiftKeychain.podspec
+++ b/SwiftKeychain.podspec
@@ -1,11 +1,10 @@
 Pod::Spec.new do |s|
-
   s.name         = "SwiftKeychain"
   s.version      = "0.1.5"
   s.summary      = "Swift wrapper around the Apple Keychain API"
 
   s.description  = <<-DESC
-                   An elegant Swift wrapper around the Apple Keychain API, made for iOS.
+                   An elegant Swift wrapper around the Apple Keychain API, made for iOS, tvOS and OSX.
                    DESC
 
   s.homepage     = "https://github.com/yankodimitrov/SwiftKeychain"
@@ -13,14 +12,14 @@ Pod::Spec.new do |s|
   s.author       = { "Yanko Dimitrov" => "yanko@yankodimitrov.com" }
   s.social_media_url   = "https://twitter.com/_yankodimitrov"
 
-  s.platform     = :ios, "8.0"
   s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.9"
+  s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => "https://github.com/yankodimitrov/SwiftKeychain.git", :tag => "v#{s.version}" }
   s.source_files  = "SwiftKeychain/Keychain/*.swift"
-  
+
   s.framework  = "Security"
 
   s.requires_arc = true
-
 end

--- a/SwiftKeychain.xcodeproj/project.pbxproj
+++ b/SwiftKeychain.xcodeproj/project.pbxproj
@@ -225,6 +225,8 @@
 		D96F8C521A12823A00CCEB81 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0720;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Yanko Dimitrov";
 				TargetAttributes = {

--- a/SwiftKeychain/Keychain/Keychain.swift
+++ b/SwiftKeychain/Keychain/Keychain.swift
@@ -70,8 +70,8 @@ public class Keychain: KeychainService {
     /**
         Updates or adds the given keychain item.
         
-        :param: key The keychain item to update or add
-        :returns: An NSError if something goes wrong, nil otherwise
+        - parameter key: The keychain item to update or add
+        - returns: An NSError if something goes wrong, nil otherwise
      */
     public func update(key: KeychainItem) -> NSError? {
         

--- a/SwiftKeychain/Keychain/KeychainItem.swift
+++ b/SwiftKeychain/Keychain/KeychainItem.swift
@@ -15,7 +15,7 @@ public protocol KeychainItem {
     /**
         Make a KeychainQuery for the specified KeychainService
         
-        :param: keychain - KeychainService instance
+        - parameter keychain: - KeychainService instance
     */
     func makeQueryForKeychain(keychain: KeychainService) -> KeychainQuery
     
@@ -23,14 +23,14 @@ public protocol KeychainItem {
         Returns a dictionary wtih the Keychain fields and their values
         that will be saved in the Keychain.
         
-        :returns: dictionary
+        - returns: dictionary
     */
     func fieldsToLock() -> [NSObject: AnyObject]
     
     /**
         Decodes the obtained from the Keychain data
         
-        :param: data - the NSData stored in the Keychain
+        - parameter data: - the NSData stored in the Keychain
     */
     func unlockData(data: NSData)
 }

--- a/SwiftKeychain/ViewController.swift
+++ b/SwiftKeychain/ViewController.swift
@@ -32,11 +32,11 @@ class ViewController: UIViewController {
         
         if let passcode = keychain.get(key).item?.value {
             
-            println("\(key.name) value: [\(passcode)]")
+            print("\(key.name) value: [\(passcode)]")
             
         } else {
             
-            println("can't find the [\(key.name)] key in the keychain")
+            print("can't find the [\(key.name)] key in the keychain")
         }
     }
     
@@ -50,33 +50,33 @@ class ViewController: UIViewController {
         
         if let error = keychain.add(key) {
         
-            println("error adding the passcode key")
+            print("error adding the passcode key")
             
         } else {
             
-            println(">> added the passcode key")
+            print(">> added the passcode key")
         }
         
         printGenericKey(key)
         
         if let error = keychain.update(updateKey) {
             
-            println("error updating the passcode key")
+            print("error updating the passcode key")
             
         } else {
     
-            println(">> updated the passcode key")
+            print(">> updated the passcode key")
         }
         
         printGenericKey(updateKey)
         
         if let error = keychain.remove(key) {
             
-            println("error deleting the passcode key")
+            print("error deleting the passcode key")
             
         } else {
             
-            println(">> removed the passcode key from the keychain")
+            print(">> removed the passcode key from the keychain")
         }
     }
     


### PR DESCRIPTION
We have been using your lib from within https://github.com/p2/OAuth2 for a while now as a submodule on tvOS works perfectly. In an effort to simplify things I would like to add tvOS and OSX support to the pod to be able to use your lib as a dependency. CocoaPods also seems to have some issue with submodules.