### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ do {
 ```
 
 ## Installation
-SwiftKeychain requires Swift 2.0 and XCode 7 and supports iOS, OSX, watchOS and tvOS.
+SwiftKeychain requires Swift 2.0 and Xcode 7 and supports iOS, OSX, watchOS and tvOS.
 
 #### Manually
 Copy the <code>Keychain/Keychain.swift</code> file to your project.


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
